### PR TITLE
Rename GitHub workflow job

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -3,7 +3,7 @@ name: Run pre-commit hooks
 on: [push]
 
 jobs:
-    execute-pre-commit:
+    pre-commit-hooks:
         runs-on: ubuntu-20.04
         steps:
             - name: Checkout jupyter-quickstart source code


### PR DESCRIPTION
Rename the GitHub workflow job from `execute-pre-commit-hooks` -> `pre-commit-hooks`.